### PR TITLE
feat: Update service worker for improved caching strategy and PWA for robust offline Service Worker config

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,62 +1,159 @@
-const CACHE_NAME = 'medical-recorder-v1';
-const urlsToCache = [
+// Versioned caches
+const CACHE_VERSION = 'v4';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
+
+// Detect Vite dev scope (so we fully bypass in development)
+const DEV_HOSTS = ['localhost', '127.0.0.1'];
+const DEV_PORT = '8080';
+const IS_DEV_SCOPE = DEV_HOSTS.includes(self.location.hostname) && self.location.port === DEV_PORT;
+
+// Minimal precache of app shell assets available at runtime
+const PRECACHE_URLS = [
   '/',
-  '/src/main.tsx',
-  '/src/index.css',
-  '/src/App.tsx',
-  '/src/pages/Index.tsx',
-  // Add other critical assets
+  '/manifest.json',
+  '/favicon.ico',
+  // Add other public/ assets as needed (do not include /src/* which doesn't exist in production)
 ];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then((cache) => {
-        return cache.addAll(urlsToCache);
-      })
-  );
-});
-
-self.addEventListener('fetch', (event) => {
-  // If the request is a blob: URL, do not intercept — let browser handle it
-  try {
-    if (event.request.url.startsWith('blob:')) {
-      return; // no event.respondWith -> browser default handling
-    }
-  } catch (e) {
-    // ignore
-  }
-  // If the request includes a Range header, bypass cache to avoid partial content issues
-  const rangeHeader = event.request.headers.get('range');
-  if (rangeHeader) {
-    // For blob/video playback with Range requests, just forward to network
-    event.respondWith(fetch(event.request));
-    return;
-  }
-
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Cache hit - return response
-        if (response) {
-          return response;
-        }
-        return fetch(event.request);
+    (async () => {
+      if (IS_DEV_SCOPE) {
+        // In dev, don't cache anything and activate immediately
+        self.skipWaiting();
+        return;
       }
-    )
+      const cache = await caches.open(STATIC_CACHE);
+      await cache.addAll(PRECACHE_URLS);
+      // Activate the new SW immediately
+      self.skipWaiting();
+    })()
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName);
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.map((key) => {
+          if (key !== STATIC_CACHE && key !== RUNTIME_CACHE) {
+            return caches.delete(key);
           }
         })
       );
-    })
+      // Control any open clients as soon as possible
+      await self.clients.claim();
+    })()
   );
 });
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+
+  // In development, completely bypass the SW so dev/HMR works
+  if (IS_DEV_SCOPE) return;
+
+  // Do not interfere with non-GET requests
+  if (req.method !== 'GET') return;
+
+  const url = new URL(req.url);
+
+  // Never intercept the service worker file or Vite dev/HMR endpoints
+  if (
+    url.pathname === '/sw.js' ||
+    url.pathname.startsWith('/@vite') ||
+    url.pathname.startsWith('/@react-refresh') ||
+    url.pathname.startsWith('/src/')
+  ) {
+    return;
+  }
+
+  // Let the browser handle blob: URLs
+  try {
+    if (req.url.startsWith('blob:')) return;
+  } catch {}
+
+  // Bypass cache for Range requests (e.g., video playback)
+  if (req.headers.get('range')) {
+    event.respondWith(fetch(req));
+    return;
+  }
+
+  // Only handle same-origin requests
+  if (url.origin !== self.location.origin) return;
+
+  // App navigation: try network first, fallback to cached app shell
+  if (req.mode === 'navigate') {
+    event.respondWith(networkFirst(req, true));
+    return;
+  }
+
+  const assetLike =
+    url.pathname.startsWith('/assets/') ||
+    ['script', 'style', 'image', 'font'].includes(req.destination);
+
+  if (assetLike) {
+    // Static assets: cache first
+    event.respondWith(cacheFirst(req));
+    return;
+  }
+
+  // Other same-origin GET requests: network first, fallback to cache
+  event.respondWith(networkFirst(req));
+});
+
+async function cacheFirst(req) {
+  const cache = await caches.open(RUNTIME_CACHE);
+  const cached = await cache.match(req);
+  if (cached) return cached;
+  try {
+    const res = await fetch(req);
+    if (isCacheableResponse(res)) {
+      cache.put(req, res.clone());
+    }
+    return res;
+  } catch (e) {
+    // As last resort, return any cached fallback for navigation
+    if (req.mode === 'navigate') {
+      const fallback = await caches.match('/');
+      if (fallback) return fallback;
+    }
+    throw e;
+  }
+}
+
+async function networkFirst(req, isNavigation = false) {
+  const cache = await caches.open(RUNTIME_CACHE);
+  try {
+    const res = await fetch(req);
+    if (isCacheableResponse(res)) {
+      cache.put(req, res.clone());
+    }
+    return res;
+  } catch (e) {
+    const cached = await cache.match(req);
+    if (cached) return cached;
+    if (isNavigation) {
+      const fallback = await caches.match('/');
+      if (fallback) return fallback;
+    }
+    // Return a basic Response instead of throwing to avoid unhandled promise rejections
+    return new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
+  }
+}
+
+function isCacheableResponse(res) {
+  try {
+    return res && res.status === 200 && (res.type === 'basic' || res.type === 'opaqueredirect' || res.type === 'default');
+  } catch {
+    return false;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,8 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-// Register service worker for offline functionality
-if ('serviceWorker' in navigator) {
+// Register service worker for offline functionality (production only)
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js')
       .then((registration) => {
@@ -13,6 +13,14 @@ if ('serviceWorker' in navigator) {
         console.log('SW registration failed: ', registrationError);
       });
   });
+} else {
+  // In development, skip SW to prevent caching/HMR conflicts and clean up any previous registrations
+  if ('serviceWorker' in navigator && !import.meta.env.PROD) {
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      if (regs.length) console.log(`Unregistering ${regs.length} service worker(s) in development`);
+      regs.forEach((r) => r.unregister());
+    });
+  }
 }
 
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary

**Improve PWA offline behavior and prevent dev/HMR conflicts.**

---

### Key Changes

- **Register Service Worker only in production** (`src/main.tsx`).
- **Rewrite `public/sw.js`**:
  - Use versioned caches.
  - Add `skipWaiting` and `clients.claim`.
  - Implement route-based strategies:
    - **Network-first** for navigations (with offline fallback to `/`).
    - **Cache-first** for assets.
- **Bypass fetch handling on `localhost:8080`** to keep Vite dev stable.
  - Ignore `blob:` URLs, Range requests, and Vite/HMR endpoints.
- **Add explicit 503 fallback response** to avoid unhandled promise rejections.

---

### Testing

1. Run: `bun run build && bun run preview`
2. Open [http://localhost:4173](http://localhost:4173) online to warm cache.
3. Toggle **Offline** in DevTools and refresh; app shell and cached assets should load.
4. In dev ([http://localhost:8080](http://localhost:8080)), no SW should be active.  
   If previously installed, unregister and clear storage.

---

### Notes

- Bump `CACHE_VERSION` to force cache refresh on updates.
- If serving under a subpath in production, set Vite `base` accordingly.